### PR TITLE
grab release keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: neuroc.deps
 Type: Package
 Title: Parses Dependencies for GitHub Packges
-Version: 0.16.0
+Version: 0.16.1
 Author: John Muschelli
 Maintainer: John Muschelli <muschellij2@gmail.com>
 Description: Uses functions to interface with 'GitHub' to 

--- a/R/use_neuroc_template.R
+++ b/R/use_neuroc_template.R
@@ -192,6 +192,9 @@ neuroc_key = function(
   if (dev) {
     outdev = "DEVEL_"
   }
+  if (deployment) {
+    outdev = paste0(outdev,"RELEASE_")
+  }
   user = neuroc_user(
     user = user,
     dev = dev,


### PR DESCRIPTION
Adjusted the `neuroc_key` function to be able to grab the newly added release specific AppVeyor keys (we ignore Travis as this stage).